### PR TITLE
Hide beta features for production on iOS

### DIFF
--- a/App/Modules/Discover/Home/Screen.js
+++ b/App/Modules/Discover/Home/Screen.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { ScrollView } from 'react-native'
 import PropTypes from 'prop-types'
 
+import { isIOSProduction } from 'App/Services/Properties'
+
 import {
   Container,
   Footer,
@@ -27,29 +29,31 @@ export default class Screen extends Component {
       onPress } = this.props
     return (
       <Container>
-        <ScrollView style={{ marginBottom: 210 }}>
-          <List title='Featured' cols={2}>
-            <FeaturedListItem
-              image={Images.featured.led}
-              title='Blink'
-              onPress={() => { onPress('Blink') }} />
-            <FeaturedListItem
-              icon={'heartbeat'}
-              iconColor={Colors.red}
-              title='Heart Beat'
-              onPress={() => { onPress('Heart Beat') }} />
-          </List>
-          <List title='Projects'>
-            <CompactListItem
-              icon='circle-o'
-              title='Hello World'
-              onPress={() => { onPress('Hello World') }} />
-            <CompactListItem
-              icon='circle-o'
-              title='Dance Show'
-              onPress={() => { onPress('Dance Show') }} />
-          </List>
-        </ScrollView>
+        {!isIOSProduction() &&
+          <ScrollView style={{ marginBottom: 210 }}>
+            <List title='Featured' cols={2}>
+              <FeaturedListItem
+                image={Images.featured.led}
+                title='Blink'
+                onPress={() => { onPress('Blink') }} />
+              <FeaturedListItem
+                icon={'heartbeat'}
+                iconColor={Colors.red}
+                title='Heart Beat'
+                onPress={() => { onPress('Heart Beat') }} />
+            </List>
+            <List title='Projects'>
+              <CompactListItem
+                icon='circle-o'
+                title='Hello World'
+                onPress={() => { onPress('Hello World') }} />
+              <CompactListItem
+                icon='circle-o'
+                title='Dance Show'
+                onPress={() => { onPress('Dance Show') }} />
+            </List>
+          </ScrollView>
+        }
         <Modal
           navigation={this.props.navigation}
           show={showNotReadyModal}

--- a/App/Modules/Home/Screen.js
+++ b/App/Modules/Home/Screen.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import { isIOSProduction } from 'App/Services/Properties'
+
 import { Container, List, ListItem, BottomNav } from 'App/Components'
 
 export default class Screen extends Component {
@@ -12,28 +14,49 @@ export default class Screen extends Component {
     const { onNavigatePress } = this.props
     return (
       <Container>
-        <List>
-          <ListItem
-            title='Play & Explore'
-            text='Let’s play'
-            button='Play'
-            onPress={() => { onNavigatePress('PlayScreen') }} />
-          <ListItem
-            title='Discover'
-            text='Let’s see what you can do'
-            button='Discover'
-            onPress={() => { onNavigatePress('DiscoverScreen') }} />
-          <ListItem
-            title='Learn'
-            text='You’ll be a guru in no time'
-            button='Learn'
-            onPress={() => { onNavigatePress('LearnScreen') }} />
-          <ListItem
-            title='Lab'
-            text='Get under the hood'
-            button='Lab'
-            onPress={() => { onNavigatePress('LabScreen') }} />
-        </List>
+        {!isIOSProduction() &&
+          <List>
+            <ListItem
+              title='Play & Explore'
+              text='Let’s play'
+              button='Play'
+              onPress={() => { onNavigatePress('PlayScreen') }} />
+            <ListItem
+              title='Discover'
+              text='Let’s see what you can do'
+              button='Discover'
+              onPress={() => { onNavigatePress('DiscoverScreen') }} />
+            <ListItem
+              title='Learn'
+              text='You’ll be a guru in no time'
+              button='Learn'
+              onPress={() => { onNavigatePress('LearnScreen') }} />
+            <ListItem
+              title='Lab'
+              text='Get under the hood'
+              button='Lab'
+              onPress={() => { onNavigatePress('LabScreen') }} />
+          </List>
+        }
+        {isIOSProduction() &&
+          <List>
+            <ListItem
+              title='Play & Explore'
+              text='Let’s play'
+              button='Play'
+              onPress={() => { onNavigatePress('PlayScreen') }} />
+            <ListItem
+              title='Discover'
+              text='Let’s see what you can do'
+              button='Discover'
+              onPress={() => { onNavigatePress('DiscoverScreen') }} />
+            <ListItem
+              title='Learn'
+              text='You’ll be a guru in no time'
+              button='Learn'
+              onPress={() => { onNavigatePress('LearnScreen') }} />
+          </List>
+        }
         <BottomNav
           onRatePress={() => { onNavigatePress('RateScreen') }}
           onHomePress={() => {}}

--- a/App/Modules/Learn/Lessons/Screen.js
+++ b/App/Modules/Learn/Lessons/Screen.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { ScrollView } from 'react-native'
 import PropTypes from 'prop-types'
 
+import { isIOSProduction } from 'App/Services/Properties'
+
 import {
   Container,
   Footer,
@@ -28,25 +30,36 @@ export default class Screen extends Component {
     return (
       <Container>
         <ScrollView style={{ marginBottom: 210 }}>
-          <List>
-            <ListHeader title='Lessons' />
-            <CompactListItem
-              icon='circle-o'
-              title='Get Started'
-              onPress={() => { onPress('Get Started') }} />
-            <CompactListItem
-              icon='circle-o'
-              title='Play Time'
-              onPress={() => { onPress('Play Time') }} />
-            <CompactListItem
-              icon='circle-o'
-              title='Customize'
-              onPress={() => { onPress('Customize') }} />
-            <CompactListItem
-              icon='circle-o'
-              title='Code Remix'
-              onPress={() => { onPress('Code Remix') }} />
-          </List>
+          {!isIOSProduction() &&
+            <List>
+              <ListHeader title='Lessons' />
+              <CompactListItem
+                icon='circle-o'
+                title='Get Started'
+                onPress={() => { onPress('Get Started') }} />
+              <CompactListItem
+                icon='circle-o'
+                title='Play Time'
+                onPress={() => { onPress('Play Time') }} />
+              <CompactListItem
+                icon='circle-o'
+                title='Customize'
+                onPress={() => { onPress('Customize') }} />
+              <CompactListItem
+                icon='circle-o'
+                title='Code Remix'
+                onPress={() => { onPress('Code Remix') }} />
+            </List>
+          }
+          {isIOSProduction() &&
+            <List>
+              <ListHeader title='Lessons' />
+              <CompactListItem
+                icon='circle-o'
+                title='Get Started'
+                onPress={() => { onPress('Get Started') }} />
+            </List>
+          }
         </ScrollView>
         <Modal
           navigation={this.props.navigation}

--- a/App/Modules/Play/Home/Screen.js
+++ b/App/Modules/Play/Home/Screen.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
+import { isIOSProduction } from 'App/Services/Properties'
+
 import {
   Container,
   Modal,
@@ -26,21 +28,32 @@ export default class Screen extends Component {
       onPress } = this.props
     return (
       <Container scrollable>
-        <List>
-          <ListHeader title='Level 1' count={3} completed={0} />
-          <CompactListItem
-            icon='circle-o'
-            title='Get Started'
-            onPress={onPress.getStarted} />
-          <CompactListItem
-            icon='circle-o'
-            title='Explore'
-            onPress={onPress.explore} />
-          <CompactListItem
-            icon='circle-o'
-            title='Play a game'
-            onPress={onPress.playGame} />
-        </List>
+        {!isIOSProduction() &&
+          <List>
+            <ListHeader title='Level 1' count={3} completed={0} />
+            <CompactListItem
+              icon='circle-o'
+              title='Get Started'
+              onPress={onPress.getStarted} />
+            <CompactListItem
+              icon='circle-o'
+              title='Explore'
+              onPress={onPress.explore} />
+            <CompactListItem
+              icon='circle-o'
+              title='Play a game'
+              onPress={onPress.playGame} />
+          </List>
+        }
+        {isIOSProduction() &&
+          <List>
+            <ListHeader title='Level 1' count={1} completed={0} />
+            <CompactListItem
+              icon='circle-o'
+              title='Get Started'
+              onPress={onPress.getStarted} />
+          </List>
+        }
         <List title='Explore'>
           <ListItem
             image={Images.controls}
@@ -55,27 +68,29 @@ export default class Screen extends Component {
             text='Beep bop boopity beep'
             onPress={onPress.beep} />
         </List>
-        <List title='Games' cols={2}>
-          <SquareListItem
-            icon='play'
-            iconStyle={{marginLeft: 4}}
-            title='Drive'
-            text='Vroom vroom'
-            onPress={onPress.drive} />
-          <SquareListItem
-            icon='play'
-            iconStyle={{marginLeft: 4}}
-            title='Dance'
-            text='Let’s boogie'
-            onPress={onPress.dance} />
-          <SquareListItem
-            icon='play'
-            iconStyle={{marginLeft: 4}}
-            title='Find a friend'
-            text='Humans are nice'
-            disabled
-            onPress={onPress.findAFriend} />
-        </List>
+        {!isIOSProduction() &&
+          <List title='Games' cols={2}>
+            <SquareListItem
+              icon='play'
+              iconStyle={{marginLeft: 4}}
+              title='Drive'
+              text='Vroom vroom'
+              onPress={onPress.drive} />
+            <SquareListItem
+              icon='play'
+              iconStyle={{marginLeft: 4}}
+              title='Dance'
+              text='Let’s boogie'
+              onPress={onPress.dance} />
+            <SquareListItem
+              icon='play'
+              iconStyle={{marginLeft: 4}}
+              title='Find a friend'
+              text='Humans are nice'
+              disabled
+              onPress={onPress.findAFriend} />
+          </List>
+        }
         <Modal
           navigation={this.props.navigation}
           show={showNotReadyModal}

--- a/App/Services/Properties/index.js
+++ b/App/Services/Properties/index.js
@@ -46,6 +46,10 @@ export const isIOS12OrHigher = () => {
   return (majorVersionIOS >= 12)
 }
 
+export const isIOSProduction = () => {
+  return (Platform.OS === 'ios' && Config.ENV === 'production')
+}
+
 export const enrichProperties = (properties) => {
   if (!properties) {
     properties = {}


### PR DESCRIPTION
Closes #1

List of changes:
 - Add isIOSProduction function in Properties service
 - Hide beta features in the Home, Discover, Learn and Play modules
   if the app is running in production on iOS